### PR TITLE
Improve processing of CASE expression

### DIFF
--- a/antlr4/PostgreSQLParser.g4
+++ b/antlr4/PostgreSQLParser.g4
@@ -1222,7 +1222,7 @@ expr
     | identifier
     | CAST OPEN_PAREN expr AS type CLOSE_PAREN
     | correlation_name DOT column_name
-    | CASE WHEN predicate THEN expr (ELSE expr)? END
+    | case_expr
     | expr OPEN_BRACKET expr COLON expr CLOSE_BRACKET
     | expr COLON_COLON type
     | expr DOT (identifier | STAR)
@@ -1239,6 +1239,11 @@ bool_expr
     | NOT bool_expr
     | bool_expr AND bool_expr
     | bool_expr OR bool_expr
+    ;
+
+case_expr
+    : CASE expr (WHEN expr THEN expr)+ (ELSE expr)? END
+    | CASE (WHEN predicate THEN expr)+ (ELSE expr)? END
     ;
 
 expr_list


### PR DESCRIPTION
Current version has bad processing of multiple WHEN in CASE such as
```sql
case
  when a = 'b' then 1
  when a = 'c' then 2
  else 100
end
```

The solution as copied from TSqlParser.g4 [1]

Changes in test_coverage the next.

Command | Accuracy was | Accuracy become
-- | -- | --
CREATE POLICY | 65/78 (83.33%) | 66/78 (84.62%)
SELECT | 6243/7447 (83.83%) | 6257/7447 (84.02%)

1. https://github.com/antlr/grammars-v4/blob/master/tsql/TSqlParser.g4#L2822